### PR TITLE
Collect coverage from tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gitignore
 .DS_Store
 node_modules/
+coverage/

--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
 # Match Madness - Japanese Kanji Learning Game
+
 Match Madness is a web-based game inspired by Duolingo's Match Madness game mode, designed to facilitate learning Japanese Kanji in a fun and interactive manner. It allows players to match Kanji characters with their readings by connecting them in pairs.
 
 ![Alt text](matchMadness.png)
+
 # Features
+
 Two columns of Kanji characters and their readings.
 Connect matching Kanji-reading pairs to see the glossary.
 
 # Future Plans
+
 - Words Madness Mode: Implement a new game mode where a single Kanji character is displayed, and users input its meaning. Points are earned for correct translations.
 - Customization Options: Allow users to customize game settings, number of Kanji characters displayed, favourite words for review etc.
 
 # Motivation
+
 The project originated from the need for a more engaging and interactive approach to learning Japanese Kanji. Traditional methods often involve rote memorization, which can be tedious and discouraging. Match Madness aims to provide a gamified learning experience that promotes repeated exposure to Kanji characters in a playful manner.
 
 # Contributing
+
 Contributions to Match Madness are welcome! To contribute:
 
 1. Fork the repository.
@@ -24,13 +30,40 @@ Contributions to Match Madness are welcome! To contribute:
 6. Push your changes to your forked repository.
 7. Submit a pull request with a detailed explanation of your changes.
 
+## Development
+
+1. Install dependencies with
+
+```
+npm install
+```
+
+2. To run tests:
+
+- uncomment import statements at the beginning of `script.js`
+- uncomment export statement at the end of `script.js`
+- uncomment export statement at the end of `dic.js`
+- run:
+
+```
+npm test
+```
+
+3. To run application:
+
+- undo changes from step 2
+- open `index.html` in the browser
+
 # Issues
+
 If you encounter any bugs, have suggestions for improvements, or want to discuss features, please submit an issue through the GitHub Issues tab. Your feedback is valuable and helps in enhancing the game for all users.
 
 # Technologies Used
+
 - HTML5
 - CSS3
 - JavaScript (Vanilla)
 
 # Credits
+
 This project was created by Marcin Majka. Special thanks to Duolingo for the inspiration.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Just like in Duolingo. But better!",
   "main": "script.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "keywords": [],
   "author": "",
@@ -17,5 +17,13 @@
     "tabWidth": 2,
     "semi": true,
     "singleQuote": true
+  },
+  "jest": {
+    "collectCoverage": true,
+    "coverageDirectory": "coverage",
+    "coverageReporters": [
+      "text",
+      "html"
+    ]
   }
 }

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-// const { JM } = require('./dic')
+const { JM } = require('./dic');
 
 /**
  * Shuffle (randomize the order of) an array of leftColumnValues.
@@ -384,16 +384,23 @@ const formatTime = (time) => {
   return time < 10 ? `0${time}` : time;
 };
 
-window.addEventListener('load', (state) => {
-  state = { ...initialState };
-  // We are starting the game when the page is loaded - before that, we don't have the divs to work with (they are not rendered yet).
-  // Create the initial state of the game - generate the divs with leftColumnValues and rightColumnValues in HTML.
-  setupRound(state, shuffledLeftValRightValGlossary, pairsToRenderCount);
-  starTimer(state);
-});
+if (typeof window !== 'undefined') {
+  // NOTE: In node environment (e.g. when we are running tests) the window
+  // object is not defined, because it belongs to the browser environment.
+  // By checking if window is defined, we can make sure that the code inside
+  // this `if` block is only executed in the browser environment.
 
-// module.exports = {
-//   shuffleArray,
-//   createLeftColValRightColValGlossaryTriplets,
-//   formatTime,
-// }
+  window.addEventListener('load', (state) => {
+    state = { ...initialState };
+    // We are starting the game when the page is loaded - before that, we don't have the divs to work with (they are not rendered yet).
+    // Create the initial state of the game - generate the divs with leftColumnValues and rightColumnValues in HTML.
+    setupRound(state, shuffledLeftValRightValGlossary, pairsToRenderCount);
+    starTimer(state);
+  });
+}
+
+module.exports = {
+  shuffleArray,
+  createLeftColValRightColValGlossaryTriplets,
+  formatTime,
+};


### PR DESCRIPTION
This PR:

- Adds coverage to the tests
- Fixes broken test by not using `window` object in the node environment

## What is test coverage
A percentage of code executed (aka "covered") in at least one test. "Code" can mean different things: conditions, individual lines.. We stick to "individual lines of code" here.

## How is it useful
To spot places that we missed when writing tests. These are most likely to introduce bugs in the future, e.g. during a refactor. 
100% coverage **is not a must and doesn't mean perfect code**. The code can be fundamentally wrong and still be covered fully.
Sometimes the infrastructure layer is so big that it skews the image (e.g. there is no sense in testing the framework itself - the authors already did that, hopefully) - thus the coverage drops below expected numbers).

Still, it's a good practice to aim at ~90%. 

## How to get coverage

1. Run tests normally (`npm test`).
2. You will notice that a new directory was created, `coverage/`. This directory contains the results of checking coverage in a nice format - a simple website is generated that allows you to visually understand the results. 
3. Open `coverage/index.html` to study the results.
4. The coverage directory is constantly changing so we don't add it to the repo (it is ignored in .gitignore)
![matchmadness-coverage](https://github.com/MarcinMajka/MatchMadness/assets/17732172/a86f5457-f712-4c11-878f-ef25dc6098c9)

